### PR TITLE
Append http to front of curl call

### DIFF
--- a/identity-tools/generate-identity.sh
+++ b/identity-tools/generate-identity.sh
@@ -33,7 +33,7 @@ function jsonValue() {
 }
 
 getEdgeStatus() {
-    edge_status=$(curl localhost:${EDGE_CORE_PORT}/status)
+    edge_status=$(curl http://localhost:${EDGE_CORE_PORT}/status)
     OU=$(jsonValue $edge_status account-id)
     internalid=$(jsonValue $edge_status internal-id)
     lwm2mserveruri=$(jsonValue $edge_status lwm2m-server-uri)


### PR DESCRIPTION
On ubuntu 20 (potentially more, didn't check other Ubuntu versions), curl did not understand just `localhost`.
It needed `http` appended before the localhost to successfully call out to the REST server.