### PR TITLE
Fix geo printing in info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Pelion Edge utilities 2.0.10
+1. [info] Fix geolocation information printing for multi-word cases (like New York).
+1. [info] Remove wigwag directory paths
+
 ## Pelion Edge utilities 2.0.9
 1. [info] Read the hardware version from /proc/device-tree/model
 1. [info] Correctly read the CPU temperature

--- a/info-tool/info
+++ b/info-tool/info
@@ -263,13 +263,13 @@ geo(){
 	_placeTitle "Geographic Information"
 	out=$(curl -m 1 -s ipinfo.io)
 	if [[ "$out" != *"timed"* ]]; then
-		PUBIP=$(echo "$out" | grep ip\" | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//' -e 's/"$//')
-		CITY=$(echo "$out" | grep city | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//' -e 's/"$//')
-		REGION=$(echo "$out" | grep region | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//' -e 's/"$//')
-		COUNTRY=$(echo "$out" | grep country | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//' -e 's/"$//')
-		ZIP=$(echo "$out" | grep postal | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//' -e 's/"$//')
-		LL=$(echo "$out" | grep loc | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//' -e 's/"$//')
-		ORG=$(echo "$out" | grep org | sed -e 's/"org"://'| sed -e 's/^   "//' -e 's/",$//' -e 's/"$//')
+		PUBIP=$(echo "$out" | jq -r ".ip?")
+		CITY=$(echo "$out" | jq -r ".city?")
+		REGION=$(echo "$out" | jq -r ".region")
+		COUNTRY=$(echo "$out" | jq -r ".country?")
+		ZIP=$(echo "$out" | jq -r ".postal?")
+		LL=$(echo "$out" | jq -r ".loc?")
+		ORG=$(echo "$out" | jq -r ".org?")
 		_placeLine "  - Public IP:" "$PUBIP"
 		_placeLine "  - City:" "$CITY"
 		_placeLine "  - Region:" "$REGION"


### PR DESCRIPTION
The geo printing was failing for anything that had two parts.
The curl results we get is a json file and unfortunately awk inteprets
every single space as a "new field". Thus any information that had
two parts in like, North Ostrobothnia would come out only as "North".

We already use jq in other places in the same script, so why not use
that instead? With -r option we do not even need any funky sed things
to strip parenthesis etc.