### PR TITLE
fw-tools/testnet.sh - add credential path, k8s, gateways - no snap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Pelion Edge utilities 2.0.10
+## Pelion Edge utilities 2.0.11
 1. [info] Fix geolocation information printing for multi-word cases (like New York).
-1. [info] Remove wigwag directory paths
+1. [common] Convert all tabs to spaces in script files.
+
+## Pelion Edge utilities 2.0.10
+1. [fw-tools] Tool for checking Izuma cloud connections (in case of firewalls blocking etc.)
 
 ## Pelion Edge utilities 2.0.9
 1. [info] Read the hardware version from /proc/device-tree/model

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # pe-utils
-utilities and a light-weight programs for Pelion Edge
+
+Utilities and a light-weight programs for Izuma Edge

--- a/fw-tools/testnet.sh
+++ b/fw-tools/testnet.sh
@@ -7,6 +7,8 @@
 #
 # Credential files will not be found otherwise.
 #
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRED_DIR="$SCRIPT_DIR/credentials"
 temp=$(mktemp -d /tmp/IzumaNetTest-XXXXX)
 bootT=$temp/bootstrap.txt
 LWT=$temp/test-lwm2m.txt
@@ -56,7 +58,7 @@ test_bootstrap() {
     verbose "--------------------------------------------"
     verbose "Uses openssl to connect to bootstrap server using device credentials."
     verbose "Write openssl output to $bootT."
-    echo | openssl s_client -CAfile credentials/bootstrap.pem -key credentials/device01_key.pem -cert credentials/device01_cert.pem -connect tcp-bootstrap.us-east-1.mbedcloud.com:5684 2>"$bootT" >"$bootT"
+    echo | openssl s_client -CAfile "$CRED_DIR/bootstrap.pem" -key "$CRED_DIR/device01_key.pem" -cert "$CRED_DIR/device01_cert.pem" -connect tcp-bootstrap.us-east-1.mbedcloud.com:5684 2>"$bootT" >"$bootT"
 
     # get openssl return code
     RESULT=$(grep 'Verify return code' "$bootT")
@@ -80,7 +82,7 @@ test_lwm2m() {
     verbose "----------------------------------------"
     verbose "Uses openssl to connect to LwM2M server using device credentials."
     verbose "Write openssl output to $LWT."
-    echo | openssl s_client -CAfile credentials/lwm2m.pem -key credentials/device01_key.pem -cert credentials/device01_cert.pem -connect lwm2m.us-east-1.mbedcloud.com:"$port" 2>"$LWT" >"$LWT"
+    echo | openssl s_client -CAfile "$CRED_DIR/lwm2m.pem" -key "$CRED_DIR/device01_key.pem" -cert "$CRED_DIR/device01_cert.pem" -connect lwm2m.us-east-1.mbedcloud.com:"$port" 2>"$LWT" >"$LWT"
     # get openssl return code
     RESULT=$(grep "Verify return code" "$LWT")
 

--- a/fw-tools/testnet.sh
+++ b/fw-tools/testnet.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 #
 # Copyright (c) 2022 Izuma Networks
-#
-# Please run this script while being in the same folder as the script
-# ./testnet.sh
-#
-# Credential files will not be found otherwise.
+# 
+# Check connectivity to Izuma Cloud services
+# - Via multiple ports (443, 5864)
+# - Please note for bootstrap and LwM2M by default 5864 (CoAP)
+#   is used, but Client/Edge has config "CUSTOM_PORT" which
+#   allows you to use port 443 as well.
+# - k8s and gateway service is available only via port 443.
 #
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CRED_DIR="$SCRIPT_DIR/credentials"
 temp=$(mktemp -d /tmp/IzumaNetTest-XXXXX)
 bootT=$temp/bootstrap.txt
+k8T=$temp/k8s.txt
+gwT=$temp/gateway.txt
 LWT=$temp/test-lwm2m.txt
 L3T=$temp/layer3.txt
 L4T=$temp/layer4.txt
@@ -58,7 +62,7 @@ test_bootstrap() {
     verbose "--------------------------------------------"
     verbose "Uses openssl to connect to bootstrap server using device credentials."
     verbose "Write openssl output to $bootT."
-    echo | openssl s_client -CAfile "$CRED_DIR/bootstrap.pem" -key "$CRED_DIR/device01_key.pem" -cert "$CRED_DIR/device01_cert.pem" -connect tcp-bootstrap.us-east-1.mbedcloud.com:5684 2>"$bootT" >"$bootT"
+    echo | openssl s_client -CAfile "$CRED_DIR/bootstrap.pem" -key "$CRED_DIR/device01_key.pem" -cert "$CRED_DIR/device01_cert.pem" -connect tcp-bootstrap.us-east-1.mbedcloud.com:"$port" 2>"$bootT" >"$bootT"
 
     # get openssl return code
     RESULT=$(grep 'Verify return code' "$bootT")
@@ -103,6 +107,55 @@ test_lwm2m() {
     fi
 }
 
+test_k8s() {
+    verbose "Test k8s server connection (port $port)"
+    verbose "-------------------------------------"
+    verbose "Uses openssl to connect to k8s server."
+    verbose "Write openssl output to $k8T."
+    echo | openssl s_client -connect k8s.us-east-1.mbedcloud.com:"$port" 2>"$k8T" >"$k8T"
+
+    # get openssl return code
+    RESULT=$(grep 'Verify return code' "$bootT")
+    if [ -z "$RESULT" ]; then
+        clihelp::failure "openssl failed with: $(cat "$k8T")"
+    fi
+    # print result
+    CODE=$(echo "$RESULT" | awk -F' ' '{print $4}')
+    if [ "$CODE" = 0 ]; then
+        clihelp::success "TLS to k8s server (port $port)"
+    else
+        clihelp::failure "TLS to k8s server (port $port)"
+        echo "--------------"
+        echo "$RESULT"
+        echo "--------------"
+    fi
+}
+
+test_gateway() {
+    verbose "Test gateway server connection (port $port)"
+    verbose "------------------------------------------"
+    verbose "Uses openssl to connect to gateway server."
+    verbose "Write openssl output to $gwT."
+    echo | openssl s_client -connect gateways.us-east-1.mbedcloud.com:"$port" 2>"$gwT" >"$gwT"
+
+    # get openssl return code
+    RESULT=$(grep 'Verify return code' "$gwT")
+    if [ -z "$RESULT" ]; then
+        clihelp::failure "openssl failed with: $(cat "$gwT")"
+    fi
+    # print result
+    CODE=$(echo "$RESULT" | awk -F' ' '{print $4}')
+    if [ "$CODE" = 0 ]; then
+        clihelp::success "TLS to gateway server (port $port)"
+    else
+        clihelp::failure "TLS to gateway server (port $port)"
+        echo "--------------"
+        echo "$RESULT"
+        echo "--------------"
+    fi
+}
+
+
 test_L3() {
     _url() {
         if [[ $(ping -q -c 1 "$1" >>"$L3T" 2>&1) -eq 0 ]]; then
@@ -113,7 +166,7 @@ test_L3() {
     }
     verbose "Test Layer 3 (requires icmp ping)"
     verbose "---------------------------------"
-    _url api.snapcraft.io
+    _url bootstrap.us-east-1.mbedcloud.com
     _url lwm2m.us-east-1.mbedcloud.com
 }
 
@@ -125,13 +178,14 @@ test_L4() {
             clihelp::failure "netcat $1 $2"
         fi
     }
-    verbose "Test Layer 4 (requires nc), port 443 and 5684"
-    verbose "---------------------------------------------"
-    _nc api.snapcraft.io 443
+    verbose "Test Layer 4 (requires nc)"
+    verbose "--------------------------"
     _nc bootstrap.us-east-1.mbedcloud.com 443
     _nc bootstrap.us-east-1.mbedcloud.com 5684
     _nc lwm2m.us-east-1.mbedcloud.com 443
     _nc lwm2m.us-east-1.mbedcloud.com 5684
+    _nc k8s.us-east-1.mbedcloud.com 443
+    _nc gateways.us-east-1.mbedcloud.com 443
 }
 
 main() {
@@ -142,6 +196,9 @@ main() {
     port=443
     test_bootstrap
     test_lwm2m
+    # K8S and Gateway server only operate on port 443
+    test_k8s
+    test_gateway
     if [[ "$DONTDELETE" -eq 0 ]]; then
         rm -rf "$temp"
     else


### PR DESCRIPTION
# Changes

* In case you execute the scripts from some other place than where the script is located, you have to use the full path to the credentials.
* Add k8s, gateways as tested addresses.
* Remove snap as tested address.

[x] pysh-check is clean

# Testing

```
jannek@p520:/ssd/pe-utils$ testnet.sh
[   OK   ]	ping bootstrap.us-east-1.mbedcloud.com
[   OK   ]	ping lwm2m.us-east-1.mbedcloud.com
[   OK   ]	netcat bootstrap.us-east-1.mbedcloud.com 443
[   OK   ]	netcat bootstrap.us-east-1.mbedcloud.com 5684
[   OK   ]	netcat lwm2m.us-east-1.mbedcloud.com 443
[   OK   ]	netcat lwm2m.us-east-1.mbedcloud.com 5684
[   OK   ]	netcat k8s.us-east-1.mbedcloud.com 443
[   OK   ]	netcat gateways.us-east-1.mbedcloud.com 443
[   OK   ]	TLS to bootstrap server (port 5684)
[   OK   ]	TLS to LwM2M server (port 5684)
[   OK   ]	TLS to bootstrap server (port 443)
[   OK   ]	TLS to LwM2M server (port 443)
[   OK   ]	TLS to k8s server (port 443)
[   OK   ]	TLS to gateway server (port 443)
```

