### PR TITLE
Update info tool version/name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Pelion Edge utilities 2.0.11
+## Izuma Edge utilities 2.0.12
+1. [info] Update version information and tool name (Relay -> Edge).
+
+## Izuma Edge utilities 2.0.11
 1. [info] Fix geolocation information printing for multi-word cases (like New York).
 1. [common] Convert all tabs to spaces in script files.
 

--- a/info-tool/info
+++ b/info-tool/info
@@ -32,7 +32,7 @@ MAGENTA="$(tput setaf 5)"
 CYAN="$(tput setaf 6)"
 WHITE="$(tput setaf 7)"
 ERROR="${REV}Error:${NORM}"
-version="1.9"
+version="2.0.12"
 LogToTerm=1
 loglevel=info;
 
@@ -506,7 +506,7 @@ fi
 
 
 Stats(){
-    _placeHeader "Relay Information utility version $version"
+    _placeHeader "Edge Information utility version $version"
 }
 
 _placeAbout(){


### PR DESCRIPTION
Instead of relay, calling it edge info now.
Update version from 1.9 to 2.0.12.

Almost as if this should be x.y.z and we should sed it with the build packing tools to match the recipe version? @jenia81  @petedyerarm ? 
