### PR TITLE
GitHub action - count based PR checker

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -1,5 +1,5 @@
 name: PR-check
-run-name: ${{ github.actor }} Pull Request - shellcheck
+run-name: ${{ github.actor }} PR checker
 on: [push]
 jobs:
   run-shellcheck:
@@ -11,3 +11,20 @@ jobs:
       - run: fw-tools/testnet.sh
       - run: shellcheck info-tool/info
       - run: info-tool/info
+  run-pysh-check:
+    runs-on: ubuntu-22.04
+    env:
+      PA_TOKEN: ${{ secrets.ACCESS_TOKEN }} # IzumaBOT Access Token
+    steps:
+      - uses: actions/checkout@v3
+      # Install pyshcheck tooling
+      - run: sudo apt install pycodestyle pydocstyle black
+      # git instead of rules to use access token
+      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
+      - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
+      - run: git config --list
+      # Linux coreutils is already installed wc -command can be found.
+      - run: git clone git@github.com:PelionIoT/scripts-internal.git
+      #- run: git clone https://github.com/PelionIoT/scripts-internal.git
+      - run: echo "." >scripts-internal/.nopyshcheck
+      - run: .github/workflows/pysh-checker.sh ${{ github.event.repository.default_branch }} ${{ github.ref_name }}

--- a/.github/workflows/pysh-checker.sh
+++ b/.github/workflows/pysh-checker.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Izuma Networks
+#
+# Arguments: $1 - default branch name (master or main typically)
+#            $1 - PR branch name
+set -e
+echo "default branch = $1 and PR branch = $2"
+# scripts-internal was already cloned by the pr-checker.yml
+# No point in the checking the scripts-internal, let's stop that.
+echo "." >scripts-internal/.nopyshcheck
+# This is what we SHOULD do, but can't due to too many findings.
+#status=$(./scripts-internal/pysh-check/pysh-check.sh --workdir .)
+
+# Get all branches, default clone is shallow
+git fetch --all
+
+# Get reference count of pysh-check issues
+git checkout "$1"
+ref_count=$(./scripts-internal/pysh-check/pysh-check.sh --workdir . | wc -l)
+
+# Checkout the pr branch again, get it's count
+git checkout "$2"
+count=$(./scripts-internal/pysh-check/pysh-check.sh --workdir . | wc -l)
+echo "Finding(s) count before = $ref_count, finding(s) count now = $count"
+# Do we have more findings that in master?
+if ((count>ref_count));then
+    # Return with error code
+    echo "Oh no, we cannot make matters worse."
+    exit 1
+fi
+decrease=$((ref_count-count))
+if ((decrease>0));then
+    echo "Excellent, $decrease findings less than earlier!"
+else
+    echo "Good, you did not make matters worse."
+fi
+exit 0


### PR DESCRIPTION
* Limit the # of issues with a count-based approach. 
* Private repo cloning with IzumaBOT access token.

## Todos

- [N/A] Changelog updated
- [x] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferrably less)
- [N/A] Will tag a proper release, if need be.
- [N/A] Will update required recipes/builds as well.
