### PR TITLE
Updated for new name for pe-terminal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Izuma Edge utilities 2.0.15
+1. [info] Update info tool to use edge-terminal instead of pe-terminal
+
 ## Izuma Edge utilities 2.0.14
 1. [info] Update info tool to auto-detect the location of edge-core and pe-terminal from the 2 possible locations.
 1. [info] Update info tool to handle different output formats of ifconfig when determining IP addresses.

--- a/info-tool/info
+++ b/info-tool/info
@@ -492,8 +492,8 @@ procState(){
         _pstate "maestro" "maestro-config.yaml" "maestro"
         _pstate "fluentbit" "td-agent-bit" "td-agent-bit"
         _pstate "devicedb" "devicedb.yaml" "devicedb" "started via maestro"
-        if [ -e "/edge/system/bin/pe-terminal" ]; then
-            _pstate "edge-terminal" "pe-terminal" "edge-relay-term"
+        if [ -e "/edge/system/bin/edge-terminal" ]; then
+            _pstate "edge-terminal" "edge-terminal" "edge-terminal"
         else
             _pstate "relay-term" "relay-term/src" "pelion-relay-term"
         fi


### PR DESCRIPTION
Update for 2.0.15 - pe-terminal is being replaced with edge-terminal.

## Todos

- [x] Changelog updated
- [x] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferrably less)
- [ ] Will tag a proper release, if need be.
- [ ] Will update required recipes/builds as well.
