### PR TITLE
generate-identity.sh - silence curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Izuma Edge utilities 2.2.1
+1. [identity-tool] Silence `curl` to have less noise in logs.
+
 ## Izuma Edge utilities 2.2.0
 1. [edge-info] Add support for different localhost:<port>/status ports (snap port `8081`, edge-core only `8080` and LmP `9091`).
 1. [edge-info] Removed unused files.

--- a/identity-tools/generate-identity.sh
+++ b/identity-tools/generate-identity.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Copyright (c) 2018, Arm Limited and affiliates.
+# Copyright (c) 2023, Izuma Networks
+#
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,7 +37,7 @@ function jsonValue() {
 }
 
 getEdgeStatus() {
-    [[ -z "$edge_status" ]] && edge_status=$(curl http://localhost:${EDGE_CORE_PORT}/status)
+    [[ -z "$edge_status" ]] && edge_status=$(curl -s http://localhost:${EDGE_CORE_PORT}/status)
     OU=`echo $edge_status | jq -r '."account-id"'`
     internalid=`echo $edge_status | jq -r '."internal-id"'`
     lwm2mserveruri=`echo $edge_status | jq -r '."lwm2m-server-uri"' | cut -d':' -f 2 | sed 's/^\/\///'`


### PR DESCRIPTION
This generates noise in the logs, we better silence curl.

Example:

```
elo 16 13:27:13 ubuntu-20-04 pelion-edge.identity[361975]:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
elo 16 13:27:13 ubuntu-20-04 pelion-edge.identity[361975]:                                  Dload  Upload   Total   Spent    Left  Speed
elo 16 13:27:13 ubuntu-20-04 pelion-edge.identity[361975]: [158B blob data]
elo 16 13:27:13 ubuntu-20-04 pelion-edge.identity[361972]: Error: edge-core is not connected yet. Its status is- error. Exited with code 1.
```

## Todos

- [x] Changelog updated
- [x] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferrably less)
- [x] Will tag a proper release, if need be.
- [ ] Will update required recipes/builds as well.
- [ ] Will update also the versions to relevant places:
    - edge-info/edge-info has the version number (around line 37)
    - identity-tools/VERSION has the version number as well.
