### PR TITLE
edge-testnet - bring back lwm2m on port 443

### DIFF
--- a/fw-tools/edge-testnet
+++ b/fw-tools/edge-testnet
@@ -262,7 +262,7 @@ main() {
     port=443
     test_bootstrap
     # Port 443 only on tcp-lwm2m URL
-    # test_lwm2m "lwm2m.us-east-1.mbedcloud.com" 443
+    test_lwm2m "lwm2m.us-east-1.mbedcloud.com" 443
     test_lwm2m "tcp-lwm2m.us-east-1.mbedcloud.com" 443
     # K8S and Gateway server only operate on port 443
     test_k8s


### PR DESCRIPTION
## Todos

- [N/A] Changelog updated
- [x] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferrably less)
- [ ] Will tag a proper release, if need be.
- [ ] Will update required recipes/builds as well.
- [x] Will update also the versions to relevant places:
    - edge-info/edge-info has the version number (around line 37)
    - identity-tools/VERSION has the version number as well.
