### PR TITLE
Fix ping tests.

### DIFF
--- a/fw-tools/edge-testnet
+++ b/fw-tools/edge-testnet
@@ -106,7 +106,6 @@ test_lwm2m() {
 
     if [ -z "$RESULT" ]; then
         clihelp::failure "openssl failed with: $(cat "$LWT")"
-        exit
     fi
     # print result
     CODE=$(echo "$RESULT" | awk -F' ' '{print $4}')
@@ -196,7 +195,7 @@ test_registry() {
 
 test_L3() {
     _url() {
-        if [[ $(ping -q -c 1 "$1" >>"$L3T" 2>&1) -eq 0 ]]; then
+        if ping -q -c 1 "$1" >>"$L3T" 2>&1; then
             clihelp::success "ping $1"
         else
             clihelp::failure "ping $1"
@@ -221,8 +220,8 @@ test_L3() {
 }
 
 test_L4() {
-    _nc() {
-        if [[ $(nc -v -w 1 "$1" "$2" >>"$L4T" 2>&1) -eq 0 ]]; then
+    _nc(){
+        if nc -v -w 1 "$1" "$2" >>"$L4T" 2>&1; then
             clihelp::success "netcat $1 $2"
         else
             clihelp::failure "netcat $1 $2"


### PR DESCRIPTION
Fixed the logic in test_L3 to correctly detect failures.

Fixed the logic in test_l$ to correctly detect failures

Fixed logic in test_lwm2m to not exit on failure detection.

## Todos

- [ ] Changelog updated
- [ ] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferrably less)
- [ ] Will tag a proper release, if need be.
- [ ] Will update required recipes/builds as well.
- [ ] Will update also the versions to relevant places:
    - edge-info/edge-info has the version number (around line 37)
    - identity-tools/VERSION has the version number as well.
