### PR TITLE
Self hosted runners & update checkout action

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -12,7 +12,7 @@ jobs:
   run-shellcheck-and-scripts:
     runs-on: [ "self-hosted", "client" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: shellcheck --version
       - name: Shellcheck fw-tools/edge-testnet
         run: shellcheck fw-tools/edge-testnet
@@ -26,7 +26,7 @@ jobs:
   run-identity-tool-tests:
     runs-on: [ "self-hosted", "client" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run identity-tools tests
         run: |
           cd identity-tools/test-cases
@@ -42,7 +42,7 @@ jobs:
     env:
       PA_TOKEN: ${{ secrets.ACCESS_TOKEN }} # IzumaBOT Access Token
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Install pyshcheck tooling
       - run: sudo apt install pycodestyle pydocstyle black
       # git instead of rules to use access token
@@ -58,7 +58,7 @@ jobs:
   run-edge-testnet:
     runs-on: [ "self-hosted", "client" ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run edge-testnet
       run: fw-tools/edge-testnet
     - name: Run edge-testnet as fake snap
@@ -67,7 +67,7 @@ jobs:
   versions-check:
     runs-on: [ "self-hosted", "client" ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: ./check_versions.sh
 
   misspell:
@@ -82,7 +82,7 @@ jobs:
   run-edge-info:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         cd edge-info
         ./edge-info

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # Install pyshcheck tooling
-      - run: sudo apt install pycodestyle pydocstyle black
+      - run: sudo apt install -y pycodestyle pydocstyle black
       # git instead of rules to use access token
       - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
       - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   run-shellcheck-and-scripts:
-    runs-on: ubuntu-22.04
+    runs-on: [ "self-hosted", "client" ]
     steps:
       - uses: actions/checkout@v3
       - run: shellcheck --version
@@ -24,7 +24,7 @@ jobs:
       - run: edge-info/edge-info
 
   run-identity-tool-tests:
-    runs-on: ubuntu-22.04
+    runs-on: [ "self-hosted", "client" ]
     steps:
       - uses: actions/checkout@v3
       - name: Run identity-tools tests
@@ -38,7 +38,7 @@ jobs:
           ./create-dev-identity.sh -d -w CI-test
 
   run-pysh-check:
-    runs-on: ubuntu-22.04
+    runs-on: [ "self-hosted", "client" ]
     env:
       PA_TOKEN: ${{ secrets.ACCESS_TOKEN }} # IzumaBOT Access Token
     steps:
@@ -56,7 +56,7 @@ jobs:
       - run: .github/workflows/pysh-checker.sh ${{ github.event.repository.default_branch }} ${{ github.ref_name }}
 
   run-edge-testnet:
-    runs-on: ubuntu-22.04
+    runs-on: [ "self-hosted", "client" ]
     steps:
     - uses: actions/checkout@v3
     - name: Run edge-testnet
@@ -65,13 +65,13 @@ jobs:
       run: SNAP=snap fw-tools/edge-testnet
 
   versions-check:
-    runs-on: ubuntu-22.04
+    runs-on: [ "self-hosted", "client" ]
     steps:
     - uses: actions/checkout@v3
     - run: ./check_versions.sh
 
   misspell:
-    runs-on: ubuntu-22.04
+    runs-on: [ "self-hosted", "client" ]
     steps:
     - name: Run misspell (findings may not increase)
       run: |


### PR DESCRIPTION
* Use self-hosted runners.
* Update actions/checkout to latest.

## Todos

- [-] Changelog updated
- [x] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferably less)
- [-] Will tag a proper release, if need be.
- [-] Will update required recipes/builds as well.
- [-] Will update also the versions to relevant places:
    - edge-info/edge-info has the version number (around line 37)
    - identity-tools/VERSION has the version number as well.
