### PR TITLE
Make CI more robust

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: [ "self-hosted", "client" ]
     steps:
       - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y shellcheck
       - run: shellcheck --version
       - name: Shellcheck fw-tools/edge-testnet
         run: shellcheck fw-tools/edge-testnet
@@ -44,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # Install pyshcheck tooling
-      - run: sudo apt install -y pycodestyle pydocstyle black
+      - run: sudo apt-get update && sudo apt-get install -y pycodestyle pydocstyle black
       # git instead of rules to use access token
       - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf "git@github.com:"
       - run: git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github".insteadOf "https://github"
@@ -75,7 +76,7 @@ jobs:
           echo "Failed to run edge-testnet -d example.com"
           exit 1
         fi
-    - name: Check if it works with a custom domain & snap
+    - name: Check if it works with a custom domain & SNAP env defined
       run: |
         if ! SNAP=snap fw-tools/edge-testnet --domain -pr-tester.pdm-sandbox.io -s --skip443 --skiptcp; then
           echo "Failed to run edge-testnet -d example.com with SNAP env defined"


### PR DESCRIPTION
Failure now in [master merge PR check](https://github.com/PelionIoT/pe-utils/actions/runs/9314734390/job/25639491726), because runner did not have `shellcheck`. Install it.
Also, prior to installation - do `sudo apt-get update`, otherwise the installations can fail randomly.

## Todos

Not applicable (NA), this is CI-only improvement.

- [ ] Changelog updated
- [ ] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferably less)
- [ ] Will tag a proper release, if need be.
- [ ] Will update required recipes/builds as well.
- [ ] Will update also the versions to relevant places:
    - edge-info/edge-info has the version number (around line 37)
    - identity-tools/VERSION has the version number as well.
