### PR TITLE
Rename edge-testnet option skiptcp to skiptcpping

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -72,19 +72,19 @@ jobs:
         fi
     - name: Check if it works with a custom domain
       run: |
-        if ! fw-tools/edge-testnet --domain -pr-tester.pdm-sandbox.io -s --skip443 --skiptcp; then
+        if ! fw-tools/edge-testnet --domain -pr-tester.pdm-sandbox.io -s --skip443 --skiptcpping; then
           echo "Failed to run edge-testnet -d example.com"
           exit 1
         fi
     - name: Check if it works with a custom domain & SNAP env defined
       run: |
-        if ! SNAP=snap fw-tools/edge-testnet --domain -pr-tester.pdm-sandbox.io -s --skip443 --skiptcp; then
+        if ! SNAP=snap fw-tools/edge-testnet --domain -pr-tester.pdm-sandbox.io -s --skip443 --skiptcpping; then
           echo "Failed to run edge-testnet -d example.com with SNAP env defined"
           exit 1
         fi
     - name: Check if it works with expected failures
       run: |
-        fw-tools/edge-testnet --domain -pr-tester.pdm-sandbox.io -s --skiptcp > expect-some-fails.txt || true
+        fw-tools/edge-testnet --domain -pr-tester.pdm-sandbox.io -s --skiptcpping > expect-some-fails.txt || true
         grep "Some tests failed." expect-some-fails.txt
 
   versions-check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Izuma Edge utilities 2.3.6
 1. [fw-tools] - fix handling `-h` (help) option.
-1. [fw-tools] - support for custom domains (--domain) added, options to skip https/port443 check (--skip443) and tcp-bootstrap (--skiptcp).
+1. [fw-tools] - support for custom domains (`--domain`) added, options to skip https/port443 check (`--skip443`) and tcp-bootstrap ping (`--skiptcpping`).
 
 ## Izuma Edge utilities 2.3.5
 1. [fw-tools] - remove `ping` test from `serial-vault-partners.canonical.com`, it is not responding to `ping` anymore.

--- a/fw-tools/edge-testnet
+++ b/fw-tools/edge-testnet
@@ -38,7 +38,7 @@ L4T=$temp/layer4.txt
 VERBOSE=0
 DONTDELETE=0
 SKIPHTTPS=0
-SKIPTCP=0
+SKIPTCPPING=0
 
 NORM="\u001b[0m"
 #BOLD="\u001b[1m"
@@ -221,7 +221,7 @@ test_L3() {
         local SERVER_NAME=$1
         
         _url "$SERVER_NAME""$DOMAIN_NAME"
-        if [[ "$SKIPTCP" -eq 0 ]]; then
+        if [[ "$SKIPTCPPING" -eq 0 ]]; then
             _url tcp-"$SERVER_NAME""$DOMAIN_NAME"
         fi
         if [[ "$TEST_UDP" -eq 1 ]]; then
@@ -365,22 +365,22 @@ main() {
 
 displayHelp() {
     echo "Usage: $0 -options"
-    echo "  -d         do not delete temporary storage"
-    echo "  -v         verbose output"
-    echo "  -e         debug"    
-    echo "  -s         skip cert validation in TLS tests"
-    echo "  --skip443  skip tests for port 443"
-    echo "  --skiptcp  skip testing tcp-bootstrap URL"
-    echo "  -h/-H      show this help dialog"
-    echo "  --domain   domain name"
-    echo "  --env      environment. Can be integration/os2/production"
+    echo "  -d              do not delete temporary storage"
+    echo "  -v              verbose output"
+    echo "  -e              debug"    
+    echo "  -s              skip cert validation in TLS tests"
+    echo "  --skip443       skip tests for port 443"
+    echo "  --skiptcpping   skip testing tcp-bootstrap URL"
+    echo "  -h/-H           show this help dialog"
+    echo "  --domain        domain name"
+    echo "  --env           environment. Can be integration/os2/production"
     echo "  if neither --domain or --env aren't supplied, the default is production env."
     echo "  --domain and --env can't be supplied together."
     exit
 }
 
 argprocessor() {
-    args=$(getopt -o hHdevs --l skip443,skiptcp,udp,env:,domain: -- "$@")
+    args=$(getopt -o hHdevs --l skip443,skiptcpping,udp,env:,domain: -- "$@")
     if [[ -z "$args" ]]; then
         usage
     fi
@@ -412,7 +412,7 @@ argprocessor() {
             #
             --skip443) SKIPHTTPS=1; shift 1;;
             #
-            --skiptcp) SKIPTCP=1; shift 1;;
+            --skiptcpping) SKIPTCPPING=1; shift 1;;
             #
             --) shift; break ;;
             #


### PR DESCRIPTION
It more exactly describes what gets disabled. It's not disabling TCP tests overall, just the ping to tcp-bootstrap.

## Todos

- [x] Changelog updated
- [x] Run `shellcheck` or `pysh-check` before committing code - no more warnings than earlier (preferably less)
- [x] Will tag a proper release, if need be.
- [] Will update required recipes/builds as well.
- [x] Will update also the versions to relevant places:
    - edge-info/edge-info has the version number (around line 37)
    - identity-tools/VERSION has the version number as well.
